### PR TITLE
32-errorhandling

### DIFF
--- a/server/functions.py
+++ b/server/functions.py
@@ -106,6 +106,18 @@ def alpha(xs_returns: pd.Series, xs_bmk_returns: pd.Series, annualized: bool = T
     X = xs_bmk_returns
     Y = xs_returns
 
+    # Ensure X and Y are numeric
+    X = pd.to_numeric(X, errors='coerce')
+    Y = pd.to_numeric(Y, errors='coerce')
+
+    # Drop any rows with NaN values in either X or Y
+    valid = X.notna() & Y.notna()
+    X = X[valid]
+    Y = Y[valid]
+
+    if len(X) < 2 or len(Y) < 2:
+        return 0
+
     X = sm.add_constant(X)
     model = sm.OLS(Y, X).fit()
 
@@ -132,6 +144,18 @@ def beta(xs_returns: pd.Series, xs_bmk_returns: pd.Series) -> float:
     X = xs_bmk_returns
     Y = xs_returns
 
+    # Ensure X and Y are numeric
+    X = pd.to_numeric(X, errors='coerce')
+    Y = pd.to_numeric(Y, errors='coerce')
+
+    # Drop any rows with NaN values in either X or Y
+    valid = X.notna() & Y.notna()
+    X = X[valid]
+    Y = Y[valid]
+
+    if len(X) < 2 or len(Y) < 2:
+        return 0
+    
     X = sm.add_constant(X)
     model = sm.OLS(Y, X).fit()
 
@@ -226,6 +250,18 @@ def alpha_contribution(xs_returns: pd.Series, xs_bmk_returns: pd.Series, weights
     X = xs_bmk_returns * weights
     Y = xs_returns
 
+    # Ensure X and Y are numeric
+    X = pd.to_numeric(X, errors='coerce')
+    Y = pd.to_numeric(Y, errors='coerce')
+
+    # Drop any rows with NaN values in either X or Y
+    valid = X.notna() & Y.notna()
+    X = X[valid]
+    Y = Y[valid]
+
+    if len(X) < 2 or len(Y) < 2:
+        return 0
+    
     X = sm.add_constant(X)
     model = sm.OLS(Y, X).fit()
 

--- a/server/service.py
+++ b/server/service.py
@@ -15,6 +15,8 @@ class Service:
 
     def fund_summary(self, start_date: str, end_date: str) -> json:
         df = self.query.get_fund_df(start_date, end_date)
+        if df.empty:
+            return json.dumps({"error": "No fund data found for the given date range."}), 404
         bmk = self.query.get_benchmark_df(start_date, end_date)
 
         with pd.option_context(
@@ -59,6 +61,8 @@ class Service:
 
     def portfolio_summary(self, fund: str, start_date: str, end_date: str) -> json:
         df = self.query.get_portfolio_df(fund, start_date, end_date)
+        if df.empty:
+            return json.dumps({"error": "No portfolio data found for the given fund and date range."}), 404
         bmk = self.query.get_benchmark_df(start_date, end_date)
 
         with pd.option_context(
@@ -177,9 +181,11 @@ class Service:
 
         return json.dumps(result)
 
-    def all_holdings_summary(self, fund: str, start_date: str, end_date: str) -> json:
-        df = Query().get_all_holdings_df(fund, start_date, end_date)
-        bmk = Query().get_benchmark_df(start_date, end_date)
+    def all_holdings_summary(self, fund: str, start_date: str, end_date: str):
+        df = self.query.get_all_holdings_df(fund, start_date, end_date)
+        if df.empty:
+            return json.dumps({"error": "No holdings data found for the given fund and date range."}), 404
+        bmk = self.query.get_benchmark_df(start_date, end_date)
         current_tickers = Query().get_current_tickers(fund)
 
         results = pd.DataFrame()


### PR DESCRIPTION
closes #32 error handling
This handles some errors that popped up when the cron jobs stopped running. This along with the error handling ticket / PR on the 47 fund frontend repo will handle those errors and the performance tab will stay up if we have another interactive broker token expire again